### PR TITLE
Initial bindings - Table and Route services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 **/*.rs.bk
 Cargo.lock
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/target
+**/*.rs.bk
+Cargo.lock
+
+/target
+**/*.rs.bk
+Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 **/*.rs.bk
 Cargo.lock
 
-/target
-**/*.rs.bk
-Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 **/target
 **/*.rs.bk
+test-data/
 Cargo.lock
-

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "osrmc-sys/src/libosrmc"]
+	path = osrmc-sys/src/libosrmc
+	url = git@github.com:daniel-j-h/libosrmc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "osrmc-sys/src/libosrmc"]
 	path = osrmc-sys/src/libosrmc
-	url = git@github.com:daniel-j-h/libosrmc.git
+	url = https://github.com/daniel-j-h/libosrmc.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,4 @@ cache: cargo
 script:
   - ./prepare-test-data.sh
   - cargo build --verbose --all
-
   - cargo test --verbose --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: rust
+
+services:
+  - docker
+
+rust:
+  - stable
+  - beta
+  - nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true
+
+cache: cargo
+
+script:
+  - ./prepare-test-data.sh
+  - cargo build --verbose --all
+
+  - cargo test --verbose --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Michael Killough <michael.killough@deliveroo.co.uk>"]
 edition = "2018"
 
 [dependencies]
+osrmc-sys = { path = "osrmc-sys", version = "0.0.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "osrm"
+version = "0.0.1"
+description = "Bindings for Open Source Routing Machine (OSRM)."
+license = "MIT"
+authors = ["Michael Killough <michael.killough@deliveroo.co.uk>"]
+edition = "2018"
+
+[dependencies]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2019 Deliveroo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Rust bindings for Open Source Routing Machine (OSRM).
 
-## Developing
+## Developing
 
 ```sh
 # Install OSRM and its dependencies.
-brew install boost tbb osrm-backend
+brew install osrm-backend
 
 # Update/initialise the libosrmc submodule:
 git submodule update --init
@@ -31,4 +31,17 @@ let result = osrm
         }],
     )?;
 assert_eq!(result.get_duration(0, 0)?, 0.0);
+```
+
+
+## Testing
+
+Requires: `wget`, `osrm-bckend`, `docker`
+
+```
+# First download/process the required maps:
+./prepare-test-data
+
+# Run tests:
+cargo test
 ```

--- a/README.md
+++ b/README.md
@@ -17,5 +17,5 @@ let result = osrm
             longitude: -0.124899,
         }],
     )?;
-assert_eq!(result, 0.0);
+assert_eq!(result.get_duration(0, 0)?, 0.0);
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# osrm-rs
+
+Rust bindings for Open Source Routing Machine (OSRM).
+
+## Example
+
+```rust
+let osrm = OSRM::new("./data/1.osrm")?;
+let result = osrm
+    .table(
+        &[Point {
+            latitude: 51.5062628,
+            longitude: -0.0996648,
+        }],
+        &[Point {
+            latitude: 51.5062628,
+            longitude: -0.124899,
+        }],
+    )?;
+assert_eq!(result, 0.0);
+```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@ Rust bindings for Open Source Routing Machine (OSRM).
 ## Developing
 
 ```sh
+# Install OSRM and its dependencies.
+brew install boost tbb osrm-backend
+
+# Update/initialise the libosrmc submodule:
 git submodule update --init
+
 cargo test
 cargo build
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Rust bindings for Open Source Routing Machine (OSRM).
 
+## Developing
+
+```sh
+git submodule update --init
+cargo test
+cargo build
+```
+
 ## Example
 
 ```rust

--- a/osrmc-sys/Cargo.toml
+++ b/osrmc-sys/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "osrmc-sys"
+version = "0.0.1"
+description = "libosrmc C bindings."
+license = "MIT"
+authors = ["Michael Killough <michael.killough@deliveroo.co.uk>"]
+edition = "2018"
+
+[dependencies]

--- a/osrmc-sys/Cargo.toml
+++ b/osrmc-sys/Cargo.toml
@@ -6,4 +6,9 @@ license = "MIT"
 authors = ["Michael Killough <michael.killough@deliveroo.co.uk>"]
 edition = "2018"
 
+[build-dependencies]
+bindgen = "0.42"
+cc = "1.0"
+pkg-config = "0.3"
+
 [dependencies]

--- a/osrmc-sys/build.rs
+++ b/osrmc-sys/build.rs
@@ -50,4 +50,5 @@ fn main() {
     // These might be needed for other features in OSRM:
     println!("cargo:rustc-link-lib=boost_filesystem");
     println!("cargo:rustc-link-lib=boost_iostreams-mt");
+    println!("cargo:rustc-link-lib=tbb");
 }

--- a/osrmc-sys/build.rs
+++ b/osrmc-sys/build.rs
@@ -1,0 +1,53 @@
+use std::env;
+use std::path::PathBuf;
+
+fn compile_libosrmc() {
+    env::set_var(
+        "CXXFLAGS",
+        env::var("CXXFLAGS").unwrap_or_default() + " -std=c++14",
+    );
+
+    let mut build = cc::Build::new();
+    build
+        .cpp(true)
+        .include("src/libosrmc/libosrmc")
+        .file("src/libosrmc/libosrmc/osrmc.cc");
+
+    let libosrm = pkg_config::Config::new()
+        .probe("libosrm")
+        .expect("Could not call pkg-config for libosrm");
+    println!("pkgconfig: {:?}", libosrm);
+    for include in libosrm.include_paths {
+        build.include(include);
+    }
+    for link_path in libosrm.link_paths {
+        if let Some(path) = link_path.to_str() {
+            println!("cargo:rustc-link-search=native={}", path);
+        }
+    }
+
+    build.compile("libosrmc");
+}
+
+fn generate_libosrmc_bindings() {
+    let bindings = bindgen::Builder::default()
+        .header("src/wrapper.h")
+        .generate()
+        .expect("Unable to generate bindings for libosrmc");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings for libosrmc");
+}
+
+fn main() {
+    compile_libosrmc();
+    generate_libosrmc_bindings();
+
+    println!("cargo:rustc-link-lib=boost_system");
+    println!("cargo:rustc-link-lib=boost_thread-mt");
+    // These might be needed for other features in OSRM:
+    println!("cargo:rustc-link-lib=boost_filesystem");
+    println!("cargo:rustc-link-lib=boost_iostreams-mt");
+}

--- a/osrmc-sys/build.rs
+++ b/osrmc-sys/build.rs
@@ -46,8 +46,15 @@ fn main() {
     generate_libosrmc_bindings();
 
     println!("cargo:rustc-link-lib=boost_system");
-    println!("cargo:rustc-link-lib=boost_thread");
     println!("cargo:rustc-link-lib=boost_filesystem");
     println!("cargo:rustc-link-lib=boost_iostreams");
     println!("cargo:rustc-link-lib=tbb");
+
+    // Boost library names differ on macOS.
+    if env::var("TARGET").unwrap().contains("apple") {
+        println!("cargo:rustc-link-lib=boost_thread-mt");
+    } else {
+        println!("cargo:rustc-link-lib=boost_thread");
+    }
+
 }

--- a/osrmc-sys/build.rs
+++ b/osrmc-sys/build.rs
@@ -46,9 +46,8 @@ fn main() {
     generate_libosrmc_bindings();
 
     println!("cargo:rustc-link-lib=boost_system");
-    println!("cargo:rustc-link-lib=boost_thread-mt");
-    // These might be needed for other features in OSRM:
+    println!("cargo:rustc-link-lib=boost_thread");
     println!("cargo:rustc-link-lib=boost_filesystem");
-    println!("cargo:rustc-link-lib=boost_iostreams-mt");
+    println!("cargo:rustc-link-lib=boost_iostreams");
     println!("cargo:rustc-link-lib=tbb");
 }

--- a/osrmc-sys/src/lib.rs
+++ b/osrmc-sys/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/osrmc-sys/src/lib.rs
+++ b/osrmc-sys/src/lib.rs
@@ -1,7 +1,5 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/osrmc-sys/src/wrapper.h
+++ b/osrmc-sys/src/wrapper.h
@@ -1,0 +1,2 @@
+#include <stddef.h>
+#include "libosrmc/libosrmc/osrmc.h"

--- a/prepare-test-data.sh
+++ b/prepare-test-data.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+mkdir test-data
+cd test-data
+
+wget -N http://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
+
+docker run -t -v $(pwd):/data osrm/osrm-backend:v5.21.0 osrm-extract -p /opt/car.lua /data/berlin-latest.osm.pbf
+docker run -t -v $(pwd):/data osrm/osrm-backend:v5.21.0 osrm-contract /data/berlin-latest.osrm

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,6 +9,9 @@ struct OsrmcError {
 
 impl_drop!(OsrmcError, osrmc_sys::osrmc_error_destruct);
 
+// This is just a thin wrapper around a std::string.
+unsafe impl Send for OsrmcError {}
+
 impl Display for OsrmcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
         unsafe {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,8 +3,6 @@ use std::ffi::{self, CStr};
 use std::fmt::{self, Debug, Display};
 use std::result::Result as StdResult;
 
-use crate::impl_drop;
-
 pub struct OsrmcError {
     handle: osrmc_sys::osrmc_error_t,
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,7 +3,7 @@ use std::ffi::{self, CStr};
 use std::fmt::{self, Debug, Display};
 use std::result::Result as StdResult;
 
-pub struct OsrmcError {
+struct OsrmcError {
     handle: osrmc_sys::osrmc_error_t,
 }
 
@@ -25,16 +25,21 @@ impl Debug for OsrmcError {
 }
 
 #[derive(Debug)]
-pub enum Error {
+enum ErrorKind {
     Osrmc(OsrmcError),
     FfiNul(ffi::NulError),
 }
 
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
-        match self {
-            Error::Osrmc(inner) => Display::fmt(inner, f),
-            Error::FfiNul(inner) => Display::fmt(inner, f),
+        match &self.kind {
+            ErrorKind::Osrmc(inner) => Display::fmt(inner, f),
+            ErrorKind::FfiNul(inner) => Display::fmt(inner, f),
         }
     }
 }
@@ -43,13 +48,17 @@ impl error::Error for Error {}
 
 impl From<osrmc_sys::osrmc_error_t> for Error {
     fn from(handle: osrmc_sys::osrmc_error_t) -> Error {
-        Error::Osrmc(OsrmcError { handle })
+        Error {
+            kind: ErrorKind::Osrmc(OsrmcError { handle }),
+        }
     }
 }
 
 impl From<ffi::NulError> for Error {
     fn from(other: ffi::NulError) -> Error {
-        Error::FfiNul(other)
+        Error {
+            kind: ErrorKind::FfiNul(other),
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,58 @@
+use std::error;
+use std::ffi::{self, CStr};
+use std::fmt::{self, Debug, Display};
+use std::result::Result as StdResult;
+
+use crate::impl_drop;
+
+pub struct OsrmcError {
+    handle: osrmc_sys::osrmc_error_t,
+}
+
+impl_drop!(OsrmcError, osrmc_sys::osrmc_error_destruct);
+
+impl Display for OsrmcError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
+        unsafe {
+            let ptr = osrmc_sys::osrmc_error_message(self.handle);
+            write!(f, "{}", CStr::from_ptr(ptr).to_string_lossy())
+        }
+    }
+}
+
+impl Debug for OsrmcError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
+        Display::fmt(self, f)
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Osrmc(OsrmcError),
+    FfiNul(ffi::NulError),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
+        match self {
+            Error::Osrmc(inner) => Display::fmt(inner, f),
+            Error::FfiNul(inner) => Display::fmt(inner, f),
+        }
+    }
+}
+
+impl error::Error for Error {}
+
+impl From<osrmc_sys::osrmc_error_t> for Error {
+    fn from(handle: osrmc_sys::osrmc_error_t) -> Error {
+        Error::Osrmc(OsrmcError { handle })
+    }
+}
+
+impl From<ffi::NulError> for Error {
+    fn from(other: ffi::NulError) -> Error {
+        Error::FfiNul(other)
+    }
+}
+
+pub type Result<T> = StdResult<T, Error>;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,7 @@ impl_drop!(OsrmcError, osrmc_sys::osrmc_error_destruct);
 
 // This is just a thin wrapper around a std::string.
 unsafe impl Send for OsrmcError {}
+unsafe impl Sync for OsrmcError {}
 
 impl Display for OsrmcError {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,7 @@ impl Debug for OsrmcError {
 
 #[derive(Debug)]
 enum ErrorKind {
+    Message(String),
     Osrmc(OsrmcError),
     FfiNul(ffi::NulError),
 }
@@ -41,6 +42,7 @@ pub struct Error {
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
         match &self.kind {
+            ErrorKind::Message(inner) => Display::fmt(inner, f),
             ErrorKind::Osrmc(inner) => Display::fmt(inner, f),
             ErrorKind::FfiNul(inner) => Display::fmt(inner, f),
         }
@@ -61,6 +63,22 @@ impl From<ffi::NulError> for Error {
     fn from(other: ffi::NulError) -> Error {
         Error {
             kind: ErrorKind::FfiNul(other),
+        }
+    }
+}
+
+impl From<String> for Error {
+    fn from(other: String) -> Error {
+        Error {
+            kind: ErrorKind::Message(other),
+        }
+    }
+}
+
+impl From<&str> for Error {
+    fn from(other: &str) -> Error {
+        Error {
+            kind: ErrorKind::Message(other.into()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,17 +35,17 @@ impl Config {
     }
 }
 
-pub struct OSRM {
+pub struct Osrm {
     handle: osrmc_sys::osrmc_osrm_t,
 }
 
-impl_drop!(OSRM, osrmc_sys::osrmc_osrm_destruct);
+impl_drop!(Osrm, osrmc_sys::osrmc_osrm_destruct);
 
-impl OSRM {
-    pub fn new<S: Into<Vec<u8>>>(path: S) -> Result<OSRM> {
+impl Osrm {
+    pub fn new<S: Into<Vec<u8>>>(path: S) -> Result<Osrm> {
         let config = Config::new(path)?;
         let handle = call_with_error!(osrmc_osrm_construct(config.handle))?;
-        Ok(OSRM { handle })
+        Ok(Osrm { handle })
     }
 
     pub fn table(&self, sources: &[Point], destinations: &[Point]) -> Result<TableResponse> {
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn it_works() {
-        let osrm = OSRM::new("./data/1.osrm").expect("uh oh");
+        let osrm = Osrm::new("./data/1.osrm").expect("uh oh");
         let result = osrm
             .table(
                 &[Point {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,10 @@ pub struct Osrm {
 
 impl_drop!(Osrm, osrmc_sys::osrmc_osrm_destruct);
 
+// This is just a thin wrapper around the OSRM C++ class, which is thread-safe.
+unsafe impl Send for Osrm {}
+unsafe impl Sync for Osrm {}
+
 impl Osrm {
     pub fn new<S: Into<Vec<u8>>>(path: S) -> Result<Osrm> {
         let config = Config::new(path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,17 @@ mod macros;
 mod route;
 
 pub use self::errors::*;
-use self::route::{RouteParameters, RouteResponse};
-use self::table::TableParameters;
-pub use self::table::TableResponse;
+pub use self::table::Response as TableResponse;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Point {
     pub latitude: f32,
     pub longitude: f32,
+}
+
+pub struct Response {
+    pub duration: f32,
+    pub distance: f32,
 }
 
 struct Config {
@@ -29,11 +32,6 @@ impl Config {
         let handle = call_with_error!(osrmc_config_construct(cstring.as_ptr()))?;
         Ok(Config { handle })
     }
-}
-
-pub struct Response {
-    pub duration: f32,
-    pub distance: f32,
 }
 
 pub struct OSRM {
@@ -63,12 +61,12 @@ impl OSRM {
     }
 
     pub fn route(&self, from: &Point, to: &Point) -> Result<Response> {
-        let mut params = RouteParameters::new()?;
+        let mut params = route::Parameters::new()?;
         params.add_coordinate(from);
         params.add_coordinate(to);
 
         let handle = call_with_error!(osrmc_route(self.handle, params.handle))?;
-        let response = RouteResponse::from(handle);
+        let response = route::Response::from(handle);
 
         Ok(Response {
             duration: response.duration()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings)]
+
 use std::ffi::CString;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,8 @@ mod table;
 mod macros;
 
 pub use self::errors::*;
-use self::table::{TableParameters, TableResponse};
+use self::table::TableParameters;
+pub use self::table::TableResponse;
 
 pub struct Point {
     latitude: f32,
@@ -40,7 +41,7 @@ impl OSRM {
         Ok(OSRM { handle })
     }
 
-    pub fn table(&self, sources: &[Point], destinations: &[Point]) -> Result<f32> {
+    pub fn table(&self, sources: &[Point], destinations: &[Point]) -> Result<TableResponse> {
         let mut params = TableParameters::new()?;
         for source in sources {
             params.add_source(source)?;
@@ -50,8 +51,7 @@ impl OSRM {
         }
 
         let handle = call_with_error!(osrmc_table(self.handle, params.handle))?;
-        let response = TableResponse::from(handle);
-        Ok(response.to_one()?)
+        Ok(TableResponse::from(handle))
     }
 }
 
@@ -74,6 +74,6 @@ mod tests {
                 }],
             )
             .expect("uh oh");
-        assert_eq!(result, 0.0);
+        assert_eq!(result.get_duration(0, 0).unwrap(), 0.0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use self::errors::{Error, Result};
 pub use self::table::Response as TableResponse;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Point {
+pub struct Coordinate {
     pub latitude: f32,
     pub longitude: f32,
 }
@@ -48,7 +48,11 @@ impl Osrm {
         Ok(Osrm { handle })
     }
 
-    pub fn table(&self, sources: &[Point], destinations: &[Point]) -> Result<TableResponse> {
+    pub fn table(
+        &self,
+        sources: &[Coordinate],
+        destinations: &[Coordinate],
+    ) -> Result<TableResponse> {
         let mut params = table::Parameters::new()?;
         for source in sources {
             params.add_source(source)?;
@@ -61,7 +65,7 @@ impl Osrm {
         Ok(TableResponse::from(handle))
     }
 
-    pub fn route(&self, from: &Point, to: &Point) -> Result<RouteResponse> {
+    pub fn route(&self, from: &Coordinate, to: &Coordinate) -> Result<RouteResponse> {
         let mut params = route::Parameters::new()?;
         params.add_coordinate(from)?;
         params.add_coordinate(to)?;
@@ -85,11 +89,11 @@ mod tests {
         let osrm = Osrm::new("./data/1.osrm").expect("uh oh");
         let result = osrm
             .table(
-                &[Point {
+                &[Coordinate {
                     latitude: 51.5062628,
                     longitude: -0.0996648,
                 }],
-                &[Point {
+                &[Coordinate {
                     latitude: 51.5062628,
                     longitude: -0.124899,
                 }],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![deny(warnings)]
 
 use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
 
 #[macro_use]
 mod macros;
@@ -30,7 +32,8 @@ struct Config {
 impl_drop!(Config, osrmc_sys::osrmc_config_destruct);
 
 impl Config {
-    fn new<S: Into<Vec<u8>>>(path: S) -> Result<Config> {
+    fn new<P: AsRef<Path>>(path: P) -> Result<Config> {
+        let path = path.as_ref().as_os_str().as_bytes();
         let cstring = CString::new(path)?;
         let handle = call_with_error!(osrmc_config_construct(cstring.as_ptr()))?;
         Ok(Config { handle })
@@ -48,7 +51,7 @@ unsafe impl Send for Osrm {}
 unsafe impl Sync for Osrm {}
 
 impl Osrm {
-    pub fn new<S: Into<Vec<u8>>>(path: S) -> Result<Osrm> {
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Osrm> {
         let config = Config::new(path)?;
         let handle = call_with_error!(osrmc_osrm_construct(config.handle))?;
         Ok(Osrm { handle })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,79 @@
+use std::ffi::CString;
+
+mod errors;
+mod table;
+#[macro_use]
+mod macros;
+
+pub use self::errors::*;
+use self::table::{TableParameters, TableResponse};
+
+pub struct Point {
+    latitude: f32,
+    longitude: f32,
+}
+
+struct Config {
+    handle: osrmc_sys::osrmc_config_t,
+}
+
+impl_drop!(Config, osrmc_sys::osrmc_config_destruct);
+
+impl Config {
+    fn new<S: Into<Vec<u8>>>(path: S) -> Result<Config> {
+        let cstring = CString::new(path)?;
+        let handle = call_with_error!(osrmc_config_construct(cstring.as_ptr()))?;
+        Ok(Config { handle })
+    }
+}
+
+pub struct OSRM {
+    handle: osrmc_sys::osrmc_osrm_t,
+}
+
+impl_drop!(OSRM, osrmc_sys::osrmc_osrm_destruct);
+
+impl OSRM {
+    pub fn new<S: Into<Vec<u8>>>(path: S) -> Result<OSRM> {
+        let config = Config::new(path)?;
+        let handle = call_with_error!(osrmc_osrm_construct(config.handle))?;
+        Ok(OSRM { handle })
+    }
+
+    pub fn table(&self, sources: &[Point], destinations: &[Point]) -> Result<f32> {
+        let mut params = TableParameters::new()?;
+        for source in sources {
+            params.add_source(source)?;
+        }
+        for destination in destinations {
+            params.add_destination(destination)?;
+        }
+
+        let handle = call_with_error!(osrmc_table(self.handle, params.handle))?;
+        let response = TableResponse::from(handle);
+        Ok(response.to_one()?)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
     fn it_works() {
-        assert_eq!(2 + 2, 4);
+        let osrm = OSRM::new("./data/1.osrm").expect("uh oh");
+        let result = osrm
+            .table(
+                &[Point {
+                    latitude: 51.5062628,
+                    longitude: -0.0996648,
+                }],
+                &[Point {
+                    latitude: 51.5062628,
+                    longitude: -0.124899,
+                }],
+            )
+            .expect("uh oh");
+        assert_eq!(result, 0.0);
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,29 @@
+/// Helper for implementing Drop for a libosrmc handle.
+#[macro_export]
+macro_rules! impl_drop {
+    ($ty:ident, $destructor:path) => {
+        impl Drop for $ty {
+            fn drop(&mut self) {
+                unsafe { $destructor(self.handle) }
+            }
+        }
+    };
+}
+
+/// Helper for calling libosrmc methods which take an error as a final parameter.
+///
+/// Takes care of passing in an empty error, and converts the response into a result.
+#[macro_export]
+macro_rules! call_with_error {
+    ($func:ident($( $arg:expr ),*)) => {{
+        let mut error = std::ptr::null_mut();
+        let result = unsafe {
+            osrmc_sys::$func($($arg,)* &mut error)
+        };
+        if !error.is_null() {
+            Err(Error::from(error))
+        } else {
+            Ok(result)
+        }
+    }};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,5 +1,4 @@
 /// Helper for implementing Drop for a libosrmc handle.
-#[macro_export]
 macro_rules! impl_drop {
     ($ty:ident, $destructor:path) => {
         impl Drop for $ty {
@@ -13,7 +12,6 @@ macro_rules! impl_drop {
 /// Helper for calling libosrmc methods which take an error as a final parameter.
 ///
 /// Takes care of passing in an empty error, and converts the response into a result.
-#[macro_export]
 macro_rules! call_with_error {
     ($func:ident($( $arg:expr ),*)) => {{
         let mut error = std::ptr::null_mut();

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,16 +1,16 @@
 use crate::errors::*;
 use crate::Point;
 
-pub struct RouteParameters {
+pub struct Parameters {
     pub handle: osrmc_sys::osrmc_route_params_t,
 }
 
-impl_drop!(RouteParameters, osrmc_sys::osrmc_route_params_destruct);
+impl_drop!(Parameters, osrmc_sys::osrmc_route_params_destruct);
 
-impl RouteParameters {
-    pub fn new() -> Result<RouteParameters> {
+impl Parameters {
+    pub fn new() -> Result<Parameters> {
         let handle = call_with_error!(osrmc_route_params_construct())?;
-        Ok(RouteParameters { handle })
+        Ok(Parameters { handle })
     }
 
     pub fn add_coordinate(&mut self, point: &Point) -> Result<()> {
@@ -23,19 +23,19 @@ impl RouteParameters {
     }
 }
 
-pub struct RouteResponse {
+pub struct Response {
     handle: osrmc_sys::osrmc_route_response_t,
 }
 
-impl_drop!(RouteResponse, osrmc_sys::osrmc_route_response_destruct);
+impl_drop!(Response, osrmc_sys::osrmc_route_response_destruct);
 
-impl From<osrmc_sys::osrmc_route_response_t> for RouteResponse {
+impl From<osrmc_sys::osrmc_route_response_t> for Response {
     fn from(handle: osrmc_sys::osrmc_route_response_t) -> Self {
-        RouteResponse { handle }
+        Response { handle }
     }
 }
 
-impl RouteResponse {
+impl Response {
     pub fn distance(&self) -> Result<f32> {
         let result = call_with_error!(osrmc_route_response_distance(self.handle))?;
         Ok(result)

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,5 +1,5 @@
 use crate::errors::*;
-use crate::Point;
+use crate::Coordinate;
 
 pub struct Parameters {
     pub handle: osrmc_sys::osrmc_route_params_t,
@@ -13,11 +13,11 @@ impl Parameters {
         Ok(Parameters { handle })
     }
 
-    pub fn add_coordinate(&mut self, point: &Point) -> Result<()> {
+    pub fn add_coordinate(&mut self, coordinate: &Coordinate) -> Result<()> {
         call_with_error!(osrmc_params_add_coordinate(
             self.handle as osrmc_sys::osrmc_params_t,
-            point.longitude,
-            point.latitude
+            coordinate.longitude,
+            coordinate.latitude
         ))?;
         Ok(())
     }

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,0 +1,48 @@
+use crate::errors::*;
+use crate::Point;
+
+pub struct RouteParameters {
+    pub handle: osrmc_sys::osrmc_route_params_t,
+}
+
+impl_drop!(RouteParameters, osrmc_sys::osrmc_route_params_destruct);
+
+impl RouteParameters {
+    pub fn new() -> Result<RouteParameters> {
+        let handle = call_with_error!(osrmc_route_params_construct())?;
+        Ok(RouteParameters { handle })
+    }
+
+    pub fn add_coordinate(&mut self, point: &Point) -> Result<()> {
+        call_with_error!(osrmc_params_add_coordinate(
+            self.handle as osrmc_sys::osrmc_params_t,
+            point.longitude,
+            point.latitude
+        ))?;
+        Ok(())
+    }
+}
+
+pub struct RouteResponse {
+    handle: osrmc_sys::osrmc_route_response_t,
+}
+
+impl_drop!(RouteResponse, osrmc_sys::osrmc_route_response_destruct);
+
+impl From<osrmc_sys::osrmc_route_response_t> for RouteResponse {
+    fn from(handle: osrmc_sys::osrmc_route_response_t) -> Self {
+        RouteResponse { handle }
+    }
+}
+
+impl RouteResponse {
+    pub fn distance(&self) -> Result<f32> {
+        let result = call_with_error!(osrmc_route_response_distance(self.handle))?;
+        Ok(result)
+    }
+
+    pub fn duration(&self) -> Result<f32> {
+        let result = call_with_error!(osrmc_route_response_duration(self.handle))?;
+        Ok(result)
+    }
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -47,8 +47,12 @@ pub struct TableResponse {
 impl_drop!(TableResponse, osrmc_sys::osrmc_table_response_destruct);
 
 impl TableResponse {
-    pub fn to_one(&self) -> Result<f32> {
-        let result = call_with_error!(osrmc_table_response_duration(self.handle, 0, 0))?;
+    pub fn get_duration(&self, from: usize, to: usize) -> Result<f32> {
+        let result = call_with_error!(osrmc_table_response_duration(
+            self.handle,
+            from as u64,
+            to as u64
+        ))?;
         Ok(result)
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,16 +1,16 @@
 use crate::{call_with_error, errors::*, impl_drop, Point};
 
-pub struct TableParameters {
+pub struct Parameters {
     pub handle: osrmc_sys::osrmc_table_params_t,
     num_coords: usize,
 }
 
-impl_drop!(TableParameters, osrmc_sys::osrmc_table_params_destruct);
+impl_drop!(Parameters, osrmc_sys::osrmc_table_params_destruct);
 
-impl TableParameters {
-    pub fn new() -> Result<TableParameters> {
+impl Parameters {
+    pub fn new() -> Result<Parameters> {
         let handle = call_with_error!(osrmc_table_params_construct())?;
-        Ok(TableParameters {
+        Ok(Parameters {
             handle,
             num_coords: 0,
         })
@@ -40,13 +40,13 @@ impl TableParameters {
     }
 }
 
-pub struct TableResponse {
+pub struct Response {
     handle: osrmc_sys::osrmc_table_response_t,
 }
 
-impl_drop!(TableResponse, osrmc_sys::osrmc_table_response_destruct);
+impl_drop!(Response, osrmc_sys::osrmc_table_response_destruct);
 
-impl TableResponse {
+impl Response {
     pub fn get_duration(&self, from: usize, to: usize) -> Result<f32> {
         let result = call_with_error!(osrmc_table_response_duration(
             self.handle,
@@ -57,8 +57,8 @@ impl TableResponse {
     }
 }
 
-impl From<osrmc_sys::osrmc_table_response_t> for TableResponse {
-    fn from(handle: osrmc_sys::osrmc_table_response_t) -> TableResponse {
-        TableResponse { handle }
+impl From<osrmc_sys::osrmc_table_response_t> for Response {
+    fn from(handle: osrmc_sys::osrmc_table_response_t) -> Response {
+        Response { handle }
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,4 +1,4 @@
-use crate::{call_with_error, errors::*, impl_drop, Point};
+use crate::{errors::*, Point};
 
 pub struct Parameters {
     pub handle: osrmc_sys::osrmc_table_params_t,

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,0 +1,60 @@
+use crate::{call_with_error, errors::*, impl_drop, Point};
+
+pub struct TableParameters {
+    pub handle: osrmc_sys::osrmc_table_params_t,
+    num_coords: usize,
+}
+
+impl_drop!(TableParameters, osrmc_sys::osrmc_table_params_destruct);
+
+impl TableParameters {
+    pub fn new() -> Result<TableParameters> {
+        let handle = call_with_error!(osrmc_table_params_construct())?;
+        Ok(TableParameters {
+            handle,
+            num_coords: 0,
+        })
+    }
+
+    fn add_coordinate(&mut self, point: &Point) -> Result<usize> {
+        call_with_error!(osrmc_params_add_coordinate(
+            self.handle as osrmc_sys::osrmc_params_t,
+            point.longitude,
+            point.latitude
+        ))?;
+        let index = self.num_coords;
+        self.num_coords += 1;
+        Ok(index)
+    }
+
+    pub fn add_source(&mut self, point: &Point) -> Result<()> {
+        let index = self.add_coordinate(point)?;
+        call_with_error!(osrmc_table_params_add_source(self.handle, index))?;
+        Ok(())
+    }
+
+    pub fn add_destination(&mut self, point: &Point) -> Result<()> {
+        let index = self.add_coordinate(point)?;
+        call_with_error!(osrmc_table_params_add_destination(self.handle, index))?;
+        Ok(())
+    }
+}
+
+pub struct TableResponse {
+    handle: osrmc_sys::osrmc_table_response_t,
+}
+
+impl_drop!(TableResponse, osrmc_sys::osrmc_table_response_destruct);
+
+impl TableResponse {
+    pub fn to_one(&self) -> Result<f32> {
+        let result = call_with_error!(osrmc_table_response_duration(self.handle, 0, 0))?;
+        Ok(result)
+    }
+}
+
+impl From<osrmc_sys::osrmc_table_response_t> for TableResponse {
+    fn from(handle: osrmc_sys::osrmc_table_response_t) -> TableResponse {
+        TableResponse { handle }
+    }
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,4 +1,4 @@
-use crate::{errors::*, Point};
+use crate::{errors::*, Coordinate};
 
 pub struct Parameters {
     pub handle: osrmc_sys::osrmc_table_params_t,
@@ -16,25 +16,25 @@ impl Parameters {
         })
     }
 
-    fn add_coordinate(&mut self, point: &Point) -> Result<usize> {
+    fn add_coordinate(&mut self, coordinate: &Coordinate) -> Result<usize> {
         call_with_error!(osrmc_params_add_coordinate(
             self.handle as osrmc_sys::osrmc_params_t,
-            point.longitude,
-            point.latitude
+            coordinate.longitude,
+            coordinate.latitude
         ))?;
         let index = self.num_coords;
         self.num_coords += 1;
         Ok(index)
     }
 
-    pub fn add_source(&mut self, point: &Point) -> Result<()> {
-        let index = self.add_coordinate(point)?;
+    pub fn add_source(&mut self, coordinate: &Coordinate) -> Result<()> {
+        let index = self.add_coordinate(coordinate)?;
         call_with_error!(osrmc_table_params_add_source(self.handle, index))?;
         Ok(())
     }
 
-    pub fn add_destination(&mut self, point: &Point) -> Result<()> {
-        let index = self.add_coordinate(point)?;
+    pub fn add_destination(&mut self, coordinate: &Coordinate) -> Result<()> {
+        let index = self.add_coordinate(coordinate)?;
         call_with_error!(osrmc_table_params_add_destination(self.handle, index))?;
         Ok(())
     }


### PR DESCRIPTION
This adds initial bindings for the Table and Route services.

The OSRM API uses a lot of C++ templates, so it is not easy to generate Rust bindings for it. The templates confuse [`bindgen`](https://github.com/rust-lang/rust-bindgen), so we'd be left creating them by hand. This instead uses the [`libosrmc`](https://github.com/daniel-j-h/libosrmc) library, which is a simple C wrapper around the C++ API, and then builds a Rust API on top of that.

The `osrmc-sys` crate should be complete, but there are other services we can add safe wrappers to in the `osrm-rs` bindings if we'd like.

Some things I haven't done:
 - I haven't added any tests, as it isn't clear how we can best test this. If we download a random OSM map, how do we assert the routes are correct?
 - No documentation yet, but we can come back and add that later.