### PR TITLE
Validate table parameters are not empty.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,10 @@ impl Osrm {
         sources: &[Coordinate],
         destinations: &[Coordinate],
     ) -> Result<TableResponse> {
+        if sources.is_empty() || destinations.is_empty() {
+            return Err("sources/destinations can not be empty".into());
+        }
+
         let mut params = table::Parameters::new()?;
         for source in sources {
             params.add_source(source)?;
@@ -133,6 +137,14 @@ mod tests {
         assert_ne!(result.get_duration(1, 0)?, 0.0);
         assert_ne!(result.get_duration(0, 0)?, result.get_duration(1, 0)?);
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_table_no_parameters() -> Result<()> {
+        let osrm = load_osrm()?;
+        let result = osrm.table(&[], &[]);
+        assert!(result.is_err());
         Ok(())
     }
 


### PR DESCRIPTION
osrm-backend will segfault (on Linux but not OS X) if it is given a
table request with empty parameters. Such a request is non-sensical, so
validate before calling OSRM and return an error.

It would have been nice to return an empty `TableResponse` instead of
returning an error, however it's awkward to do that given it's a thin
wrapper on top of the returned handle. We probably want to know we're
doing empty requests in any case.