### PR TITLE
Handle unrouteable route requests.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "osrmc-sys/src/libosrmc"]
 	path = osrmc-sys/src/libosrmc
-	url = https://github.com/daniel-j-h/libosrmc.git
+	url = https://github.com/mjkillough/libosrmc.git

--- a/prepare-test-data.sh
+++ b/prepare-test-data.sh
@@ -3,7 +3,8 @@
 mkdir test-data
 cd test-data
 
-wget -N http://download.geofabrik.de/europe/germany/berlin-latest.osm.pbf
+# Includes UAE, which has some unroutable routes.
+wget -N http://download.geofabrik.de/asia/gcc-states-latest.osm.pbf
 
-docker run -t -v $(pwd):/data osrm/osrm-backend:v5.21.0 osrm-extract -p /opt/car.lua /data/berlin-latest.osm.pbf
-docker run -t -v $(pwd):/data osrm/osrm-backend:v5.21.0 osrm-contract /data/berlin-latest.osrm
+docker run -t -v $(pwd):/data osrm/osrm-backend:v5.21.0 osrm-extract -p /opt/foot.lua /data/gcc-states-latest.osm.pbf
+docker run -t -v $(pwd):/data osrm/osrm-backend:v5.21.0 osrm-contract /data/gcc-states-latest.osrm

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,19 +99,28 @@ mod tests {
 
     use super::*;
 
-    const OSRM_FILE: &str = "./test-data/berlin-latest.osrm";
+    const OSRM_FILE: &str = "./test-data/gcc-states-latest.osrm";
 
     const COORDINATE_A: Coordinate = Coordinate {
-        latitude: 52.519930,
-        longitude: 13.438640,
+        latitude: 24.4476192,
+        longitude: 54.3710367,
     };
     const COORDINATE_B: Coordinate = Coordinate {
-        latitude: 52.525081,
-        longitude: 13.430388,
+        latitude: 24.4548709,
+        longitude: 54.391076,
     };
     const COORDINATE_C: Coordinate = Coordinate {
-        latitude: 52.513191,
-        longitude: 13.415852,
+        latitude: 24.4549789,
+        longitude: 54.376517,
+    };
+
+    const COORDINATE_BROKEN_A: Coordinate = Coordinate {
+        latitude: 25.07165,
+        longitude: 55.402115,
+    };
+    const COORDINATE_BROKEN_B: Coordinate = Coordinate {
+        latitude: 25.086226,
+        longitude: 55.385334,
     };
 
     fn load_osrm() -> Result<Osrm> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,19 @@ mod tests {
 
     const OSRM_FILE: &str = "./test-data/berlin-latest.osrm";
 
+    const COORDINATE_A: Coordinate = Coordinate {
+        latitude: 52.519930,
+        longitude: 13.438640,
+    };
+    const COORDINATE_B: Coordinate = Coordinate {
+        latitude: 52.525081,
+        longitude: 13.430388,
+    };
+    const COORDINATE_C: Coordinate = Coordinate {
+        latitude: 52.513191,
+        longitude: 13.415852,
+    };
+
     fn load_osrm() -> Result<Osrm> {
         if !Path::new(OSRM_FILE).exists() {
             return Err(format!(
@@ -116,22 +129,7 @@ mod tests {
     #[test]
     fn test_table() -> Result<()> {
         let osrm = load_osrm()?;
-        let result = osrm.table(
-            &[
-                Coordinate {
-                    latitude: 52.519930,
-                    longitude: 13.438640,
-                },
-                Coordinate {
-                    latitude: 52.525081,
-                    longitude: 13.430388,
-                },
-            ],
-            &[Coordinate {
-                latitude: 52.513191,
-                longitude: 13.415852,
-            }],
-        )?;
+        let result = osrm.table(&[COORDINATE_A, COORDINATE_B], &[COORDINATE_C])?;
 
         assert_ne!(result.get_duration(0, 0)?, 0.0);
         assert_ne!(result.get_duration(1, 0)?, 0.0);
@@ -152,30 +150,12 @@ mod tests {
     fn test_route() -> Result<()> {
         let osrm = load_osrm()?;
 
-        let result1 = osrm.route(
-            &Coordinate {
-                latitude: 52.519930,
-                longitude: 13.438640,
-            },
-            &Coordinate {
-                latitude: 52.525081,
-                longitude: 13.430388,
-            },
-        )?;
+        let result1 = osrm.route(&COORDINATE_A, &COORDINATE_B)?;
 
         assert_ne!(result1.duration, 0.0);
         assert_ne!(result1.distance, 0.0);
 
-        let result2 = osrm.route(
-            &Coordinate {
-                latitude: 52.519930,
-                longitude: 13.438640,
-            },
-            &Coordinate {
-                latitude: 52.513191,
-                longitude: 13.415852,
-            },
-        )?;
+        let result2 = osrm.route(&COORDINATE_A, &COORDINATE_C)?;
 
         assert_ne!(result2.duration, 0.0);
         assert_ne!(result2.distance, 0.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod errors;
 mod route;
 mod table;
 
-pub use self::errors::{Error, Result};
+pub use self::errors::{Error, ErrorKind, Result};
 pub use self::table::Response as TableResponse;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -20,6 +20,7 @@ pub struct Coordinate {
     pub longitude: f32,
 }
 
+#[derive(Debug)]
 pub struct RouteResponse {
     pub duration: f32,
     pub distance: f32,
@@ -98,6 +99,7 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+    use crate::errors::ErrorKind;
 
     const OSRM_FILE: &str = "./test-data/gcc-states-latest.osrm";
 
@@ -171,6 +173,16 @@ mod tests {
 
         assert_ne!(result1.duration, result2.duration);
         assert_ne!(result1.distance, result2.distance);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unroutable() -> Result<()> {
+        let osrm = load_osrm()?;
+
+        let result = osrm.route(&COORDINATE_BROKEN_A, &COORDINATE_BROKEN_B);
+        assert_eq!(result.err().unwrap().kind(), ErrorKind::NoRoute);
 
         Ok(())
     }


### PR DESCRIPTION
 - Switches to maps of the Gulf Cooperation Council, as it is easier to find a route which can't be routed (on foot/bicycle) than it is in Berlin.
 - Convert `libosrmc` errors into Strings earlier, so we can match on them.
 - Use [this change to `libosrmc`](https://github.com/daniel-j-h/libosrmc/compare/master...mjkillough:errors?expand=1) so that we can detect when a route is unrouteable.
 - Expose unrouteable routes using a new `NoRoute` error kind.

This doesn't handle unrouteable routes in table requests - they'll need to be handled slightly differently, as we receive a `null` in the JSON.