### PR TITLE
Handle 'InvalidValue' errors.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,6 +34,7 @@ pub enum ErrorKind {
         message: String,
     },
     NoRoute,
+    InvalidCoordinate,
     FfiNul(ffi::NulError),
 }
 
@@ -43,6 +44,7 @@ impl Display for ErrorKind {
             ErrorKind::Message(inner) => Display::fmt(inner, f),
             ErrorKind::Osrmc { code, message }=> write!(f, "Osrmc: {}: {}", code, message),
             ErrorKind::NoRoute => write!(f, "Impossible route between points"),
+            ErrorKind::InvalidCoordinate => write!(f, "Invalid coordinate value"),
             ErrorKind::FfiNul(inner) => Display::fmt(inner, f),
         }
     }
@@ -74,6 +76,7 @@ impl From<osrmc_sys::osrmc_error_t> for Error {
         let message = error.message().into_owned();
         let kind = match code.as_ref() {
             "NoRoute" => ErrorKind::NoRoute,
+            "InvalidValue" => ErrorKind::InvalidCoordinate,
             _ => ErrorKind::Osrmc { code, message }
         };
         Error { kind }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,11 @@ mod tests {
         longitude: 55.385334,
     };
 
+    const COORDINATE_INVALID: Coordinate = Coordinate {
+        latitude: -190.0,
+        longitude: -190.0,
+    };
+
     fn load_osrm() -> Result<Osrm> {
         if !Path::new(OSRM_FILE).exists() {
             return Err(format!(
@@ -203,6 +208,16 @@ mod tests {
 
         let result = resp.get_distance(0, 0);
         assert_eq!(result.err().unwrap().kind(), ErrorKind::NoRoute);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_coordinate() -> Result<()> {
+        let osrm = load_osrm()?;
+
+        let result = osrm.route(&COORDINATE_A, &COORDINATE_INVALID);
+        assert_eq!(result.err().unwrap().kind(), ErrorKind::InvalidCoordinate);
 
         Ok(())
     }


### PR DESCRIPTION
When an invalid (i.e. out of range) coordinate is passed to OSRM, it
returns an error 'InvalidValue'. We sometimes see this happen when we
get bad GPS data. Catch the error and turn it into something that we can
easily handle in our applications.