### PR TITLE
LOG-XXX Library Updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "osrmc-sys/src/libosrmc"]
 	path = osrmc-sys/src/libosrmc
-	url = https://github.com/daniel-j-h/libosrmc
+	url = https://github.com/daniel-j-h/libosrmc.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "osrmc-sys/src/libosrmc"]
 	path = osrmc-sys/src/libosrmc
-	url = https://github.com/mjkillough/libosrmc.git
+	url = https://github.com/daniel-j-h/libosrmc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "osrm"
-version = "0.0.1"
+version = "0.0.2"
 description = "Bindings for Open Source Routing Machine (OSRM)."
 license = "MIT"
 authors = ["Michael Killough <michael.killough@deliveroo.co.uk>"]
 edition = "2018"
 
 [dependencies]
-osrmc-sys = { path = "osrmc-sys", version = "0.0.1" }
+osrmc-sys = { path = "osrmc-sys", version = "0.0.2" }

--- a/README.md
+++ b/README.md
@@ -2,19 +2,6 @@
 
 Rust bindings for Open Source Routing Machine (OSRM).
 
-## Developing
-
-```sh
-# Install OSRM and its dependencies.
-brew install osrm-backend
-
-# Update/initialise the libosrmc submodule:
-git submodule update --init
-
-cargo test
-cargo build
-```
-
 ## Example
 
 ```rust
@@ -33,15 +20,31 @@ let result = osrm
 assert_eq!(result.get_duration(0, 0)?, 0.0);
 ```
 
+## Developing
+
+```sh
+# Install OSRM and its dependencies
+brew install osrm-backend
+# OR `brew install --HEAD deliveroo/osrm/osrm-backend` for Deliveroo's patched version
+
+# Update/initialise the libosrmc submodule
+git submodule update --init
+
+# Build library
+cargo build
+```
 
 ## Testing
 
-Requires: `wget`, `osrm-bckend`, `docker`
+```sh
+# Follow steps in `Developing` section
 
-```
-# First download/process the required maps:
-./prepare-test-data
+# Install additional dependencies
+brew install wget docker
 
-# Run tests:
+# Download/process the required maps
+./prepare-test-data.sh
+
+# Run tests
 cargo test
 ```

--- a/osrmc-sys/Cargo.toml
+++ b/osrmc-sys/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Michael Killough <michael.killough@deliveroo.co.uk>"]
 edition = "2018"
 
 [build-dependencies]
-bindgen = "0.42"
+bindgen = "0.59"
 cc = "1.0"
 pkg-config = "0.3"
 

--- a/osrmc-sys/Cargo.toml
+++ b/osrmc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osrmc-sys"
-version = "0.0.1"
+version = "0.0.2"
 description = "libosrmc C bindings."
 license = "MIT"
 authors = ["Michael Killough <michael.killough@deliveroo.co.uk>"]

--- a/osrmc-sys/build.rs
+++ b/osrmc-sys/build.rs
@@ -48,6 +48,12 @@ fn main() {
     println!("cargo:rustc-link-lib=boost_system");
     println!("cargo:rustc-link-lib=boost_filesystem");
     println!("cargo:rustc-link-lib=boost_iostreams");
+    // The homebrew `osrm-backend` package specifies tbb@2020 as a dependency which is keg only and
+    // therefore not symlinked to a directory where the linker can find it. `rustc-link-search` is a
+    // hack which tells rustc to add the TBB location to the linker search path. Note that the
+    // DYLD_LIBRARY_PATH environment variable can no longer be used on MacOS due to System Integrity
+    // Protection.
+    println!("cargo:rustc-link-search=/usr/local/opt/tbb@2020/lib");
     println!("cargo:rustc-link-lib=tbb");
 
     // Boost library names differ on macOS.

--- a/prepare-test-data.sh
+++ b/prepare-test-data.sh
@@ -6,5 +6,8 @@ cd test-data
 # Includes UAE, which has some unroutable routes.
 wget -N http://download.geofabrik.de/asia/gcc-states-latest.osm.pbf
 
-docker run -t -v $(pwd):/data osrm/osrm-backend:v5.21.0 osrm-extract -p /opt/foot.lua /data/gcc-states-latest.osm.pbf
-docker run -t -v $(pwd):/data osrm/osrm-backend:v5.21.0 osrm-contract /data/gcc-states-latest.osrm
+# This was confirmed to work with v5.26.0 which unfortunately did not have a dedicated tag at the
+# time of writing. Any future breakage could be caused by a newer version so try modifying the tag
+# from `latest` to `v5.26.0` which will hopefully be available.
+docker run -t -v $(pwd):/data osrm/osrm-backend:latest osrm-extract -p /opt/foot.lua /data/gcc-states-latest.osm.pbf
+docker run -t -v $(pwd):/data osrm/osrm-backend:latest osrm-contract /data/gcc-states-latest.osrm

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,10 +29,7 @@ impl OsrmcError {
 #[derive(Clone, Debug, PartialEq)]
 pub enum ErrorKind {
     Message(String),
-    Osrmc {
-        code: String,
-        message: String,
-    },
+    Osrmc { code: String, message: String },
     NoRoute,
     InvalidCoordinate,
     FfiNul(ffi::NulError),
@@ -42,7 +39,7 @@ impl Display for ErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
         match self {
             ErrorKind::Message(inner) => Display::fmt(inner, f),
-            ErrorKind::Osrmc { code, message }=> write!(f, "Osrmc: {}: {}", code, message),
+            ErrorKind::Osrmc { code, message } => write!(f, "Osrmc: {}: {}", code, message),
             ErrorKind::NoRoute => write!(f, "Impossible route between points"),
             ErrorKind::InvalidCoordinate => write!(f, "Invalid coordinate value"),
             ErrorKind::FfiNul(inner) => Display::fmt(inner, f),
@@ -77,7 +74,7 @@ impl From<osrmc_sys::osrmc_error_t> for Error {
         let kind = match code.as_ref() {
             "NoRoute" => ErrorKind::NoRoute,
             "InvalidValue" => ErrorKind::InvalidCoordinate,
-            _ => ErrorKind::Osrmc { code, message }
+            _ => ErrorKind::Osrmc { code, message },
         };
         Error { kind }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,10 @@ impl Osrm {
         }
 
         let handle = call_with_error!(osrmc_table(self.handle, params.handle))?;
-        Ok(TableResponse { include_distance, handle })
+        Ok(TableResponse {
+            include_distance,
+            handle,
+        })
     }
 
     pub fn route(&self, from: &Coordinate, to: &Coordinate) -> Result<RouteResponse> {
@@ -105,25 +108,25 @@ mod tests {
     const OSRM_FILE: &str = "./test-data/gcc-states-latest.osrm";
 
     const COORDINATE_A: Coordinate = Coordinate {
-        latitude: 24.4476192,
-        longitude: 54.3710367,
+        latitude: 24.447_618,
+        longitude: 54.371_037,
     };
     const COORDINATE_B: Coordinate = Coordinate {
-        latitude: 24.4548709,
-        longitude: 54.391076,
+        latitude: 24.454_87,
+        longitude: 54.391_076,
     };
     const COORDINATE_C: Coordinate = Coordinate {
-        latitude: 24.4549789,
-        longitude: 54.376517,
+        latitude: 24.454_979,
+        longitude: 54.376_52,
     };
 
     const COORDINATE_BROKEN_A: Coordinate = Coordinate {
-        latitude: 25.07165,
-        longitude: 55.402115,
+        latitude: 25.071_65,
+        longitude: 55.402_115,
     };
     const COORDINATE_BROKEN_B: Coordinate = Coordinate {
-        latitude: 25.086226,
-        longitude: 55.385334,
+        latitude: 25.086_226,
+        longitude: 55.385_334,
     };
 
     const COORDINATE_INVALID: Coordinate = Coordinate {
@@ -136,7 +139,8 @@ mod tests {
             return Err(format!(
                 "Couldn't load {}. Has `./prepare-test-data.sh` been run?",
                 OSRM_FILE
-            ))?;
+            )
+            .into());
         }
 
         let osrm = Osrm::new(OSRM_FILE)?;

--- a/src/table.rs
+++ b/src/table.rs
@@ -58,13 +58,16 @@ impl Parameters {
 
     pub fn add_source(&mut self, coordinate: &Coordinate) -> Result<()> {
         let index = self.add_coordinate(coordinate)?;
-        call_with_error!(osrmc_table_params_add_source(self.handle, index))?;
+        call_with_error!(osrmc_table_params_add_source(self.handle, index as u64))?;
         Ok(())
     }
 
     pub fn add_destination(&mut self, coordinate: &Coordinate) -> Result<()> {
         let index = self.add_coordinate(coordinate)?;
-        call_with_error!(osrmc_table_params_add_destination(self.handle, index))?;
+        call_with_error!(osrmc_table_params_add_destination(
+            self.handle,
+            index as u64
+        ))?;
         Ok(())
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -34,7 +34,10 @@ impl Parameters {
         let handle = call_with_error!(osrmc_table_params_construct())?;
 
         let annotations = Annotations::new(include_distance)?;
-        call_with_error!(osrmc_table_params_set_annotations(handle, annotations.handle))?;
+        call_with_error!(osrmc_table_params_set_annotations(
+            handle,
+            annotations.handle
+        ))?;
 
         Ok(Parameters {
             handle,


### PR DESCRIPTION
- Changes libosrmc to the original source repo as it now includes the changes that were in the fork.
- Amends the build script to allow successful linking when using homebrew installed `osrm-backend`.
- Updates the test script to use the latest `osrm-backend` image.
- Updates `bindgen`
- Updates the readme to reflect the above changes
- Increments to v0.0.2