### PR TITLE
LOG-XXX Update to maintain compatibility with new libosrmc API

### DIFF
--- a/osrmc-sys/build.rs
+++ b/osrmc-sys/build.rs
@@ -52,8 +52,10 @@ fn main() {
     // therefore not symlinked to a directory where the linker can find it. `rustc-link-search` is a
     // hack which tells rustc to add the TBB location to the linker search path. Note that the
     // DYLD_LIBRARY_PATH environment variable can no longer be used on MacOS due to System Integrity
-    // Protection.
+    // Protection. `/usr/local` is the Homebrew install path on Intel and `/opt/homebrew` is for
+    // Apple Silicon.
     println!("cargo:rustc-link-search=/usr/local/opt/tbb@2020/lib");
+    println!("cargo:rustc-link-search=/opt/homebrew/opt/tbb@2020/lib");
     println!("cargo:rustc-link-lib=tbb");
 
     // Boost library names differ on macOS.

--- a/osrmc-sys/build.rs
+++ b/osrmc-sys/build.rs
@@ -56,6 +56,7 @@ fn main() {
     // Apple Silicon.
     println!("cargo:rustc-link-search=/usr/local/opt/tbb@2020/lib");
     println!("cargo:rustc-link-search=/opt/homebrew/opt/tbb@2020/lib");
+    println!("cargo:rustc-link-search=/opt/homebrew/opt/boost/lib");
     println!("cargo:rustc-link-lib=tbb");
 
     // Boost library names differ on macOS.

--- a/src/table.rs
+++ b/src/table.rs
@@ -17,7 +17,7 @@ impl Annotations {
     }
 
     fn set_distance(&mut self) -> Result<()> {
-        call_with_error!(osrmc_table_annotations_set_distance(self.handle))?;
+        call_with_error!(osrmc_table_annotations_enable_distance(self.handle, true))?;
         Ok(())
     }
 }


### PR DESCRIPTION
The source libosrmc API was modified slightly which caused builds to fail when
attempting to set Distance table annotations. The old API was configured in a
custom fork branch but this update should be equivalent and will ensure table
responses are annotated with Distance info.